### PR TITLE
[BB-1637] Ignore permission denied error on listing document grants

### DIFF
--- a/pkg/connector/document.go
+++ b/pkg/connector/document.go
@@ -102,12 +102,18 @@ func (o *documentBuilder) Entitlements(_ context.Context, resource *v2.Resource,
 }
 
 func (o *documentBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+	l := ctxzap.Extract(ctx)
 	if resource.Id.Resource == "root" {
 		return nil, "", nil, nil
 	}
 
 	collaborators, nextToken, err := o.client.ListDocumentUserCollaborators(ctx, resource.Id.Resource, pToken.Token)
 	if err != nil {
+		// Ignore permission denied errors as they indicate no access to collaborators for this document
+		if status.Code(err) == codes.PermissionDenied {
+			l.Debug("baton-lucidchart: permission denied when listing document collaborators", zap.String("document_id", resource.Id.Resource))
+			return nil, "", nil, nil
+		}
 		return nil, "", nil, err
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of permission scenarios when viewing document collaborators, resulting in graceful error resolution instead of error propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->