### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-lucidchart/config.go
+++ b/cmd/baton-lucidchart/config.go
@@ -40,6 +40,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the Lucidchart API URL (for testing)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 
 	// ConfigurationFields defines the external configuration required for the

--- a/cmd/baton-lucidchart/config.go
+++ b/cmd/baton-lucidchart/config.go
@@ -36,6 +36,11 @@ var (
 		field.WithDefaultValue(false),
 	)
 
+	BaseURLField = field.StringField(
+		"base-url",
+		field.WithDescription("Override the Lucidchart API URL (for testing)"),
+	)
+
 	// ConfigurationFields defines the external configuration required for the
 	// connector to run. Note: these fields can be marked as optional or
 	// required.
@@ -45,6 +50,7 @@ var (
 		LucidClientSecretField,
 		LucidRefreshTokenField,
 		ExcludeShortcutsField,
+		BaseURLField,
 	}
 
 	// FieldRelationships defines relationships between the fields listed in

--- a/cmd/baton-lucidchart/config.go
+++ b/cmd/baton-lucidchart/config.go
@@ -39,6 +39,7 @@ var (
 	BaseURLField = field.StringField(
 		"base-url",
 		field.WithDescription("Override the Lucidchart API URL (for testing)"),
+		field.WithHidden(true),
 	)
 
 	// ConfigurationFields defines the external configuration required for the

--- a/cmd/baton-lucidchart/main.go
+++ b/cmd/baton-lucidchart/main.go
@@ -60,7 +60,7 @@ func getConnector(ctx context.Context, v *viper.Viper) (types.ConnectorServer, e
 	oauthConfig := &oauth2.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
-		Endpoint: oauth2.Endpoint{
+		Endpoint: oauth2.Endpoint{ //nolint:gosec // G101: OAuth2 token endpoint URL, not a credential
 			TokenURL: "https://api.lucid.co/oauth2/token",
 		},
 	}

--- a/cmd/baton-lucidchart/main.go
+++ b/cmd/baton-lucidchart/main.go
@@ -54,6 +54,7 @@ func getConnector(ctx context.Context, v *viper.Viper) (types.ConnectorServer, e
 	clientSecret := v.GetString(LucidClientSecretField.FieldName)
 	refreshToken := v.GetString(LucidRefreshTokenField.FieldName)
 	excludeShortcuts := v.GetBool(ExcludeShortcutsField.FieldName)
+	baseURL := v.GetString(BaseURLField.FieldName)
 
 	// Set up OAuth2 config
 	oauthConfig := &oauth2.Config{
@@ -70,7 +71,7 @@ func getConnector(ctx context.Context, v *viper.Viper) (types.ConnectorServer, e
 	}
 	tokenSource := oauthConfig.TokenSource(ctx, token)
 
-	cb, err := connector.New(ctx, apiKey, tokenSource, excludeShortcuts)
+	cb, err := connector.New(ctx, apiKey, tokenSource, excludeShortcuts, baseURL)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, err

--- a/pkg/connector/client/lucidchart.go
+++ b/pkg/connector/client/lucidchart.go
@@ -36,9 +36,10 @@ type LucidchartClient struct {
 	client      *uhttp.BaseHttpClient
 	tokenSource oauth2.TokenSource
 	apiKey      string
+	baseURL     string
 }
 
-func NewLucidchartClient(ctx context.Context, apiKey string, tokenSource oauth2.TokenSource) (*LucidchartClient, error) {
+func NewLucidchartClient(ctx context.Context, apiKey string, tokenSource oauth2.TokenSource, baseURL string) (*LucidchartClient, error) {
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
 	if err != nil {
 		return nil, err
@@ -49,22 +50,26 @@ func NewLucidchartClient(ctx context.Context, apiKey string, tokenSource oauth2.
 		return nil, err
 	}
 
+	if baseURL == "" {
+		baseURL = string(LucidchartApiUrl)
+	}
+
 	return &LucidchartClient{
 		client:      uhttpClient,
 		tokenSource: tokenSource,
 		apiKey:      apiKey,
+		baseURL:     baseURL,
 	}, nil
 }
 
 func (c *LucidchartClient) newRequest(
 	ctx context.Context,
-	clientUrl ClientUrl,
 	method string,
 	path string,
 	body interface{},
 	authType LucidAuthType,
 ) (*http.Request, error) {
-	urlAddress, err := url.Parse(string(clientUrl))
+	urlAddress, err := url.Parse(c.baseURL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connector/client/lucidchart_test.go
+++ b/pkg/connector/client/lucidchart_test.go
@@ -19,7 +19,7 @@ func TestExtractPageToken(t *testing.T) {
 			ExpectedToken: "",
 			ExpectedError: true,
 		},
-		{
+		{ //nolint:gosec // G101: test data containing fake pageToken, not a real credential
 			Name:          "link with token",
 			Link:          "<https://api.lucid.co/users?pageSize=1&pageToken=eyJvIjoiMSJ9>; rel=\"next\"",
 			ExpectedToken: "eyJvIjoiMSJ9",

--- a/pkg/connector/client/mutate.go
+++ b/pkg/connector/client/mutate.go
@@ -17,7 +17,7 @@ func (c *LucidchartClient) UpsertFolderUserCollaborator(ctx context.Context, fol
 		Role: role,
 	}
 
-	req, err := c.newRequest(ctx, LucidchartApiUrl, http.MethodPut, path, body, LucidAuthTypeApiKey)
+	req, err := c.newRequest(ctx, http.MethodPut, path, body, LucidAuthTypeApiKey)
 	if err != nil {
 		return nil, err
 	}
@@ -32,7 +32,7 @@ func (c *LucidchartClient) UpsertFolderUserCollaborator(ctx context.Context, fol
 func (c *LucidchartClient) DeleteFolderUserCollaborator(ctx context.Context, folderId, userId string) error {
 	path := fmt.Sprintf(DeleteFolderUserCollaboratorPath, folderId, userId)
 
-	req, err := c.newRequest(ctx, LucidchartApiUrl, http.MethodDelete, path, nil, LucidAuthTypeApiKey)
+	req, err := c.newRequest(ctx, http.MethodDelete, path, nil, LucidAuthTypeApiKey)
 	if err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func (c *LucidchartClient) UpsertDocumentUserCollaborator(ctx context.Context, d
 		Role: role,
 	}
 
-	req, err := c.newRequest(ctx, LucidchartApiUrl, http.MethodPut, path, body, LucidAuthTypeApiKey)
+	req, err := c.newRequest(ctx, http.MethodPut, path, body, LucidAuthTypeApiKey)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func (c *LucidchartClient) UpsertDocumentUserCollaborator(ctx context.Context, d
 func (c *LucidchartClient) DeleteDocumentUserCollaborator(ctx context.Context, documentId, userId string) error {
 	path := fmt.Sprintf(DeleteDocumentUserCollaboratorPath, documentId, userId)
 
-	req, err := c.newRequest(ctx, LucidchartApiUrl, http.MethodDelete, path, nil, LucidAuthTypeApiKey)
+	req, err := c.newRequest(ctx, http.MethodDelete, path, nil, LucidAuthTypeApiKey)
 	if err != nil {
 		return err
 	}

--- a/pkg/connector/client/query.go
+++ b/pkg/connector/client/query.go
@@ -22,7 +22,7 @@ var (
 func (c *LucidchartClient) ListUser(ctx context.Context, pageToken string) ([]User, string, error) {
 	var response []User
 
-	req, err := c.newRequest(ctx, LucidchartApiUrl, http.MethodGet, GetUsersPath, nil, LucidAuthTypeOAuth2)
+	req, err := c.newRequest(ctx, http.MethodGet, GetUsersPath, nil, LucidAuthTypeOAuth2)
 	if err != nil {
 		return nil, "", err
 	}
@@ -40,7 +40,7 @@ func (c *LucidchartClient) ListUser(ctx context.Context, pageToken string) ([]Us
 func (c *LucidchartClient) RootFolderContent(ctx context.Context, pageToken string) ([]FolderContent, string, error) {
 	var response []FolderContent
 
-	req, err := c.newRequest(ctx, LucidchartApiUrl, http.MethodGet, RootFolderContentPath, nil, LucidAuthTypeApiKey)
+	req, err := c.newRequest(ctx, http.MethodGet, RootFolderContentPath, nil, LucidAuthTypeApiKey)
 	if err != nil {
 		return nil, "", err
 	}
@@ -60,7 +60,7 @@ func (c *LucidchartClient) FolderContent(ctx context.Context, folderId string, p
 
 	path := fmt.Sprintf(FolderContentPath, folderId)
 
-	req, err := c.newRequest(ctx, LucidchartApiUrl, http.MethodGet, path, nil, LucidAuthTypeApiKey)
+	req, err := c.newRequest(ctx, http.MethodGet, path, nil, LucidAuthTypeApiKey)
 	if err != nil {
 		return nil, "", err
 	}
@@ -80,7 +80,7 @@ func (c *LucidchartClient) ListFolderUserCollaborators(ctx context.Context, fold
 
 	path := fmt.Sprintf(ListFolderUserCollaboratorsPath, folderId)
 
-	req, err := c.newRequest(ctx, LucidchartApiUrl, http.MethodGet, path, nil, LucidAuthTypeApiKey)
+	req, err := c.newRequest(ctx, http.MethodGet, path, nil, LucidAuthTypeApiKey)
 	if err != nil {
 		return nil, "", err
 	}
@@ -100,7 +100,7 @@ func (c *LucidchartClient) ListDocumentUserCollaborators(ctx context.Context, do
 
 	path := fmt.Sprintf(ListDocumentUserCollaboratorsPath, documentId)
 
-	req, err := c.newRequest(ctx, LucidchartApiUrl, http.MethodGet, path, nil, LucidAuthTypeApiKey)
+	req, err := c.newRequest(ctx, http.MethodGet, path, nil, LucidAuthTypeApiKey)
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/connector/client/user_management.go
+++ b/pkg/connector/client/user_management.go
@@ -15,7 +15,7 @@ type UserCreatePayload struct {
 	LastName  string   `json:"lastName"`
 	Email     string   `json:"email"`
 	Username  string   `json:"username,omitempty"`
-	Password  string   `json:"password,omitempty"`
+	Password  string   `json:"password,omitempty"` //nolint:gosec // G117: Lucidchart API request field, not a hardcoded credential
 	Roles     []string `json:"roles,omitempty"`
 }
 

--- a/pkg/connector/client/user_management.go
+++ b/pkg/connector/client/user_management.go
@@ -15,7 +15,7 @@ type UserCreatePayload struct {
 	LastName  string   `json:"lastName"`
 	Email     string   `json:"email"`
 	Username  string   `json:"username,omitempty"`
-	Password  string   `json:"password,omitempty"` //nolint:gosec // G117: Lucidchart API request field, not a hardcoded credential
+	Password  string   `json:"password,omitempty"`
 	Roles     []string `json:"roles,omitempty"`
 }
 

--- a/pkg/connector/client/user_management.go
+++ b/pkg/connector/client/user_management.go
@@ -26,7 +26,7 @@ func (c *LucidchartClient) CreateUser(ctx context.Context, payload *UserCreatePa
 	}
 
 	// Lucid recommends using the normal host for account operations.
-	req, err := c.newRequest(ctx, LucidchartApiUrl, http.MethodPost, "/users", payload, LucidAuthTypeOAuth2)
+	req, err := c.newRequest(ctx, http.MethodPost, "/users", payload, LucidAuthTypeOAuth2)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -92,7 +92,7 @@ func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, apiKey string, tokenSource oauth2.TokenSource, excludeShortcuts bool) (*Connector, error) {
+func New(ctx context.Context, apiKey string, tokenSource oauth2.TokenSource, excludeShortcuts bool, baseURL string) (*Connector, error) {
 	if apiKey == "" {
 		return nil, errors.New("apiKey is required")
 	}
@@ -101,7 +101,7 @@ func New(ctx context.Context, apiKey string, tokenSource oauth2.TokenSource, exc
 		return nil, errors.New("tokenSource is required")
 	}
 
-	lucidClient, err := client.NewLucidchartClient(ctx, apiKey, tokenSource)
+	lucidClient, err := client.NewLucidchartClient(ctx, apiKey, tokenSource, baseURL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-lucidchart/config.go,cmd/baton-lucidchart/main.go,pkg/connector/client/lucidchart.go,pkg/connector/client/mutate.go,pkg/connector/client/query.go,pkg/connector/client/user_management.go,pkg/connector/connector.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-lucidchart --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for configurable base URL in the Lucidchart connector, enabling flexibility for custom API endpoints.

* **Refactor**
  * Simplified internal URL handling in the connector client to improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->