### PR TITLE
fix: mark lucid-api-key, lucid-client-secret, lucid-refresh-token as isSecret in config_schema

### DIFF
--- a/cmd/baton-lucidchart/config.go
+++ b/cmd/baton-lucidchart/config.go
@@ -10,6 +10,7 @@ var (
 		"lucid-api-key",
 		field.WithDescription("The API key for the Lucidchart API."),
 		field.WithRequired(true),
+		field.WithIsSecret(true),
 	)
 
 	LucidClientIdField = field.StringField(
@@ -22,12 +23,14 @@ var (
 		"lucid-client-secret",
 		field.WithDescription("The OAuth2 client secret for the Lucidchart API."),
 		field.WithRequired(true),
+		field.WithIsSecret(true),
 	)
 
 	LucidRefreshTokenField = field.StringField(
 		"lucid-refresh-token",
 		field.WithDescription("The OAuth2 refresh token for the Lucidchart API."),
 		field.WithRequired(true),
+		field.WithIsSecret(true),
 	)
 
 	ExcludeShortcutsField = field.BoolField(


### PR DESCRIPTION
BREAKING: adding `isSecret: true` to these fields changes how existing configurations are stored. Customers with existing connector configurations will need to re-enter credentials after this change is deployed.

The credential field(s) are defined in Go via the baton `field` package, which is the source the config schema is derived from (no separate generated config_schema.json is committed in this repo), so adding `field.WithIsSecret(true)` to the field definition is the complete fix.

<!-- stargate: connector-secret-audit-phase11 -->