### PR TITLE
chore: add config_schema.json

### DIFF
--- a/config_schema.json
+++ b/config_schema.json
@@ -1,0 +1,138 @@
+{
+  "fields": [
+    {
+      "name": "log-level",
+      "description": "The log level: debug, info, warn, error",
+      "isOps": true,
+      "stringField": {
+        "defaultValue": "info"
+      }
+    },
+    {
+      "name": "log-level-debug-expires-at",
+      "description": "The timestamp indicating when debug-level logging should expire",
+      "isOps": true,
+      "stringField": {}
+    },
+    {
+      "name": "session-store-maximum-size",
+      "description": "The maximum size of the local in-memory session store cache in bytes.",
+      "isOps": true,
+      "intField": {
+        "defaultValue": "15728640"
+      }
+    },
+    {
+      "name": "otel-collector-endpoint",
+      "description": "The endpoint of the OpenTelemetry collector to send observability data to (used for both tracing and logging if specific endpoints are not provided)",
+      "isOps": true,
+      "stringField": {}
+    },
+    {
+      "name": "otel-collector-endpoint-tls-cert-path",
+      "description": "Path to a file containing a PEM-encoded certificate to use as a CA for TLS connections to the OpenTelemetry collector",
+      "isOps": true,
+      "stringField": {}
+    },
+    {
+      "name": "otel-collector-endpoint-tls-cert",
+      "description": "A PEM-encoded certificate to use as a CA for TLS connections to the OpenTelemetry collector",
+      "isOps": true,
+      "stringField": {}
+    },
+    {
+      "name": "otel-collector-endpoint-tls-insecure",
+      "description": "Allow insecure connections to the OpenTelemetry collector",
+      "isOps": true,
+      "boolField": {}
+    },
+    {
+      "name": "otel-tracing-disabled",
+      "description": "Disable OpenTelemetry tracing",
+      "isOps": true,
+      "boolField": {}
+    },
+    {
+      "name": "otel-logging-disabled",
+      "description": "Disable OpenTelemetry logging",
+      "isOps": true,
+      "boolField": {}
+    },
+    {
+      "name": "health-check",
+      "description": "Enable the HTTP health check endpoint",
+      "isOps": true,
+      "boolField": {}
+    },
+    {
+      "name": "health-check-port",
+      "description": "Port for the HTTP health check endpoint",
+      "isOps": true,
+      "intField": {
+        "defaultValue": "8081"
+      }
+    },
+    {
+      "name": "health-check-bind-address",
+      "description": "Bind address for health check server (127.0.0.1 for localhost-only)",
+      "isOps": true,
+      "stringField": {
+        "defaultValue": "127.0.0.1"
+      }
+    },
+    {
+      "name": "http-timeout-seconds",
+      "description": "HTTP client timeout in seconds (max 1800)",
+      "isOps": true,
+      "intField": {
+        "defaultValue": "300",
+        "rules": {
+          "lte": "1800",
+          "gte": "1"
+        }
+      }
+    },
+    {
+      "name": "lucid-api-key",
+      "displayName": "Lucidchart API Key",
+      "description": "The API key for the Lucidchart API.",
+      "isRequired": true,
+      "isSecret": true,
+      "stringField": {
+        "rules": {
+          "isRequired": true
+        }
+      }
+    },
+    {
+      "name": "oauth2",
+      "displayName": "Lucidchart OAuth2 Token",
+      "description": "The OAuth2 token for the Lucidchart API.",
+      "stringField": {
+        "type": "STRING_FIELD_TYPE_OAUTH2"
+      }
+    },
+    {
+      "name": "lucid-client-id",
+      "displayName": "Lucidchart Client ID",
+      "description": "The OAuth2 client ID for the Lucidchart API.",
+      "stringField": {}
+    },
+    {
+      "name": "lucid-client-secret",
+      "displayName": "Lucidchart Client Secret",
+      "description": "The OAuth2 client secret for the Lucidchart API.",
+      "isSecret": true,
+      "stringField": {}
+    },
+    {
+      "name": "exclude-shortcuts",
+      "displayName": "Exclude Shortcuts",
+      "description": "Exclude shortcut documents and folders",
+      "boolField": {}
+    }
+  ],
+  "displayName": "Lucidchart",
+  "helpUrl": "/docs/baton/lucidchart",
+  "iconUrl": "/static/app-icons/lucidchart.svg"
+}


### PR DESCRIPTION
## Summary
- Adds `config_schema.json` defining the connector's configuration fields

## Test plan
- [ ] Verify connector builds successfully with `go build ./cmd/baton-*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)